### PR TITLE
Adds Support for Body Text Attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ docker run --rm \
     -e GITHUB_ISSUE_API_KEY=xxxx \
     -e GITHUB_ISSUE_TITLE="issue title" \
     -e GITHUB_ISSUE_BODY="issue body" \
+    -e GITHUB_ISSUE_BODY_TEXT_ATTACHMENTS="/path/to/file/to/dump/in/issue,/path/to/another/file" \
     -e GITHUB_ISSUE_ASSIGNEES="user1,user2" \
     -e GITHUB_ISSUE_LABELS="bug" \
     -v $(pwd):$(pwd) \

--- a/cmd/drone-github-issue/config.go
+++ b/cmd/drone-github-issue/config.go
@@ -27,6 +27,12 @@ func settingsFlags(settings *plugin.Settings) []cli.Flag {
 			Destination: &settings.Body,
 		},
 		&cli.StringSliceFlag{
+			Name:        "body-text-attachments",
+			Usage:       "list of text attachments to be appended to the issue body, one after the other",
+			EnvVars:     []string{"PLUGIN_BODY_TEXT_ATTACHMENTS", "GITHUB_ISSUE_BODY_TEXT_ATTACHMENTS"},
+			Destination: &settings.BodyTextAttachments,
+		},
+		&cli.StringSliceFlag{
 			Name:        "assignees",
 			Usage:       "list of github usernames to be assigned to the github issue",
 			Value:       &cli.StringSlice{},

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -13,12 +13,13 @@ import (
 
 // Settings for the plugin.
 type Settings struct {
-	APIKey    string
-	Title     string
-	Body      string
-	Assignees cli.StringSlice
-	Labels    cli.StringSlice
-	BaseURL   string
+	APIKey              string
+	Title               string
+	Body                string
+	BodyTextAttachments cli.StringSlice
+	Assignees           cli.StringSlice
+	Labels              cli.StringSlice
+	BaseURL             string
 
 	baseURL *url.URL
 }
@@ -59,14 +60,15 @@ func (p *Plugin) Execute() error {
 	ghClient.BaseURL = p.settings.baseURL
 
 	ic := issueClient{
-		Client:    ghClient,
-		Context:   p.network.Context,
-		Owner:     p.pipeline.Repo.Owner,
-		Repo:      p.pipeline.Repo.Name,
-		Title:     p.settings.Title,
-		Body:      p.settings.Body,
-		Assignees: p.settings.Assignees.Value(),
-		Labels:    p.settings.Labels.Value(),
+		Client:              ghClient,
+		Context:             p.network.Context,
+		Owner:               p.pipeline.Repo.Owner,
+		Repo:                p.pipeline.Repo.Name,
+		Title:               p.settings.Title,
+		Body:                p.settings.Body,
+		BodyTextAttachments: p.settings.BodyTextAttachments.Value(),
+		Assignees:           p.settings.Assignees.Value(),
+		Labels:              p.settings.Labels.Value(),
 	}
 
 	_, err := ic.createIssue()


### PR DESCRIPTION
Add support for specifying text attachments to be dumped into an issue's
body. Do this to allow for output from previous DroneCI steps to be
added into the issue's message.

The version of the GitHub library used doesn't support attaching files
to the issue hence why I went with the approach of only supporting text
attachments and dumping the contents of the attachments in the issue
body.

Tested using the following command:

```
docker run --rm \
    -e DRONE_BUILD_EVENT=tag \
    -e DRONE_REPO_OWNER=evansmurithi \
    -e DRONE_REPO_NAME=drone-github-issue \
    -e DRONE_COMMIT_REF=refs/heads/main \
    -e GITHUB_ISSUE_API_KEY=xxxx \
    -e GITHUB_ISSUE_TITLE="Issue With Text Attachment" \
    -e GITHUB_ISSUE_BODY="Contents of /etc/hosts:" \
    -e GITHUB_ISSUE_BODY_TEXT_ATTACHMENTS="/etc/hosts" \
    -v $(pwd):$(pwd) \
    -w $(pwd) \
    evansmurithi/drone-github-issue
```

Which generated this issue -> https://github.com/evansmurithi/drone-github-issue/issues/3